### PR TITLE
Replaced smartquotes with normal ones

### DIFF
--- a/_posts/2023-09-03-Debian-12-with-LUKS-and-Fido2.md
+++ b/_posts/2023-09-03-Debian-12-with-LUKS-and-Fido2.md
@@ -56,7 +56,7 @@ apt install dracut fido2-tools
 Create a file called 11-fido.conf in /etc/dracut.conf.d .  Make sure this file user and group are root.  Contents of the file are below 
 ```conf
 ## Spaces in the quotes are critical.
-install_optional_items+=” /usr/lib/x86_64-linux-gnu/libz.so.* “
+install_optional_items+=" /usr/lib/x86_64-linux-gnu/libz.so.* "
 
 ## Ugly workround because the line above doesn't fetch
 ## dependencies of libfido2.so


### PR DESCRIPTION
Used:

```
find . -name "*.md" -type f -exec sed -i 's/”/"/g; s/“/"/g' {} \;
```

This was the only change (just happened to be the one post I was copy/pasting from).